### PR TITLE
Introduce JSON fixture pattern

### DIFF
--- a/spec/cookie/client_spec.rb
+++ b/spec/cookie/client_spec.rb
@@ -9,16 +9,7 @@ RSpec.describe Cookie::Client do
 
   describe ".authenticate" do
     context "when successful" do
-      let(:response_body) do
-        {
-          type: "loginResponseTokenDTO",
-          errorCode: "",
-          errorMessage: "",
-          expired: false,
-          expiredIn: 43050,
-          token: token
-        }
-      end
+      let(:response_body) { fixture("login/successful_response") }
 
       before do
         stub_request(:post, "#{described_class::BASE_URL}/login")
@@ -45,14 +36,7 @@ RSpec.describe Cookie::Client do
     end
 
     context "when authentication fails" do
-      let(:response_body) do
-        {
-          type: "loginResponseTokenDTO",
-          errorCode: "500",
-          errorMessage: "Oops! Your email or password is incorrect. Please try again.",
-          expired: false
-        }
-      end
+      let(:response_body) { fixture("login/invalid_credentials_response") }
 
       before do
         stub_request(:post, "#{described_class::BASE_URL}/login")
@@ -66,7 +50,7 @@ RSpec.describe Cookie::Client do
       it "raises an unauthorized error" do
         expect {
           described_class.authenticate(username: username, credential: credential)
-        }.to raise_error(Cookie::UnauthorizedError, response_body[:errorMessage])
+        }.to raise_error(Cookie::UnauthorizedError, response_body["errorMessage"])
       end
     end
   end

--- a/spec/cookie/resources/login_spec.rb
+++ b/spec/cookie/resources/login_spec.rb
@@ -13,16 +13,7 @@ RSpec.describe Cookie::Resources::Login do
     subject(:authenticate) { login.authenticate(username: username, credential: credential) }
 
     context "when successful" do
-      let(:response_body) do
-        {
-          type: "loginResponseTokenDTO",
-          errorCode: "",
-          errorMessage: "",
-          expired: false,
-          expiredIn: 43050,
-          token: "test-token"
-        }
-      end
+      let(:response_body) { fixture("login/successful_response") }
 
       before do
         stub_request(:post, "#{Cookie::Client::BASE_URL}/login")
@@ -42,14 +33,7 @@ RSpec.describe Cookie::Resources::Login do
     end
 
     context "when credentials are invalid" do
-      let(:response_body) do
-        {
-          type: "loginResponseTokenDTO",
-          errorCode: "500",
-          errorMessage: "Oops! Your email or password is incorrect. Please try again.",
-          expired: false
-        }
-      end
+      let(:response_body) { fixture("login/invalid_credentials_response") }
 
       before do
         stub_request(:post, "#{Cookie::Client::BASE_URL}/login")
@@ -63,7 +47,7 @@ RSpec.describe Cookie::Resources::Login do
       it "raises an unauthorized error" do
         expect { authenticate }.to raise_error(
           Cookie::UnauthorizedError,
-          response_body[:errorMessage]
+          response_body["errorMessage"]
         )
       end
     end

--- a/spec/fixtures/login/invalid_credentials_response.json
+++ b/spec/fixtures/login/invalid_credentials_response.json
@@ -1,0 +1,6 @@
+{
+  "type": "loginResponseTokenDTO",
+  "errorCode": "500",
+  "errorMessage": "Oops! Your email or password is incorrect. Please try again.",
+  "expired": false
+}

--- a/spec/fixtures/login/successful_response.json
+++ b/spec/fixtures/login/successful_response.json
@@ -1,0 +1,8 @@
+{
+  "type": "loginResponseTokenDTO",
+  "errorCode": "",
+  "errorMessage": "",
+  "expired": false,
+  "expiredIn": 43050,
+  "token": "test-token"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,18 @@ require "bundler/setup"
 require "cookie"
 require "webmock/rspec"
 
+SPEC_ROOT = File.expand_path("..", __FILE__)
+
+module FixtureHelpers
+  def fixture(path)
+    JSON.parse(
+      File.read(
+        File.join(SPEC_ROOT, "fixtures", "#{path}.json")
+      )
+    )
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -14,4 +26,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include FixtureHelpers
 end


### PR DESCRIPTION
In an effort to make it easier to autogenerate resources with an LLM, this PR moves response bodies to a JSON fixture system.
